### PR TITLE
Add unsubscribe callback when the user is deleted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![Test Coverage](https://codeclimate.com/github/LoveMondays/devise-vero/badges/coverage.svg)](https://codeclimate.com/github/LoveMondays/devise-vero)
 [![Dependency Status](https://gemnasium.com/LoveMondays/devise-vero.svg)](https://gemnasium.com/LoveMondays/devise-vero)
 
-Replace transaction emails sent by [Devise](https://github.com/plataformatec/devise) with [Vero](http://www.getvero.com) events.
+Add Vero support for an ActiveRecord object.
+- Replace transaction emails sent by [Devise](https://github.com/plataformatec/devise) with [Vero](http://www.getvero.com) events.
+- Unsubscribe the user once it's deleted from application.
 
 Tested with devise ~3.4
 

--- a/devise-vero.gemspec
+++ b/devise-vero.gemspec
@@ -10,12 +10,14 @@ Gem::Specification.new do |spec|
   spec.authors       = [
     'Estevão Mascarenhas',
     'Vinicius Negrisolo',
-    "Shane O'Grady"
+    "Shane O'Grady",
+    'Rubens Minoru Andako Bueno'
   ]
   spec.email         = [
     'estevao.am@gmail.com',
     'vinicius.negrisolo@gmail.com',
-    'shane@ogrady.ie'
+    'shane@ogrady.ie',
+    'rubensmabueno@hotmail.com'
   ]
   spec.summary       = 'Replace Devise transactional emails with Vero events.'
   spec.description   = 'Replace Devise transactional emails with Vero events.'

--- a/lib/devise/vero/model.rb
+++ b/lib/devise/vero/model.rb
@@ -1,8 +1,14 @@
+require 'vero'
+
 module Devise
   module Models
     # VeroNotification module
     module Vero
       extend ActiveSupport::Concern
+
+      included do
+        before_destroy :unsubscribe_user
+      end
 
       protected
 
@@ -37,8 +43,16 @@ module Devise
         @devise_pending_notifications ||= []
       end
 
+      def unsubscribe_user
+        vero_sender.unsubscribe
+      end
+
       def send_to_vero(notification, *args)
-        Devise::Vero::Sender.new(notification, self, *args).deliver
+        vero_sender.deliver(notification, *args)
+      end
+
+      def vero_sender
+        @vero_sender ||= Devise::Vero::Sender.new(self)
       end
     end
   end

--- a/lib/devise/vero/sender.rb
+++ b/lib/devise/vero/sender.rb
@@ -2,18 +2,21 @@ module Devise
   module Vero
     # Sender class
     class Sender
-      attr_reader :notification, :instance, :token, :args
+      attr_reader :instance
 
-      def initialize(notification, instance, *args)
-        @notification = notification
+      def initialize(instance)
         @instance = instance
-        @token = args[0] if args.any?
-        @args = args
       end
 
       # Actually send the event to Vero
-      def deliver
+      def deliver(notification, *args)
+        token = args[0] if args.any?
+
         instance.track!(notification, token: token, data: args)
+      end
+
+      def unsubscribe
+        instance.with_default_vero_context.unsubscribe!
       end
     end
   end

--- a/lib/devise/vero/version.rb
+++ b/lib/devise/vero/version.rb
@@ -1,6 +1,6 @@
 module Devise
   # Vero module to define VERSION
   module Vero
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/devise/vero/model_spec.rb
+++ b/spec/devise/vero/model_spec.rb
@@ -5,6 +5,7 @@ describe Devise::Models::Vero do
   let(:klass) do
     Class.new do
       include ActiveModel::Dirty
+      include ActiveRecord::Callbacks
       include Devise::Models::Vero
     end
   end

--- a/spec/devise/vero/sender_spec.rb
+++ b/spec/devise/vero/sender_spec.rb
@@ -1,25 +1,32 @@
 require 'spec_helper'
 
 describe Devise::Vero::Sender do
-  context 'initializing' do
-    it 'populate the token attribute with the first arg' do
-      instance = described_class.new(:test, nil, 2, 3, 4)
-      expect(instance.token).to eq(2)
-    end
-  end
-
   describe '#deliver' do
     let(:instance) { (Class.new).new }
     let(:token) { SecureRandom.hex }
     let(:notification) { :confirmation_instructions }
 
-    subject { described_class.new(:confirmation_instructions, instance, token) }
+    subject { described_class.new(instance) }
 
     it 'calls the track method' do
       allow(instance).to receive(:track!)
-      subject.deliver
+      subject.deliver(notification, token)
       expect(instance).to have_received(:track!)
         .with(notification, token: token, data: [token])
+    end
+  end
+
+  describe '#unsubscribe' do
+    let(:instance) { (Class.new).new }
+    let(:vero_context) { Vero::Context.new }
+
+    subject { described_class.new(instance) }
+
+    it 'calls the unsubscribe method from vero_context' do
+      expect(vero_context).to receive(:unsubscribe!) {}
+
+      allow(instance).to receive(:with_default_vero_context) { vero_context }
+      subject.unsubscribe
     end
   end
 end


### PR DESCRIPTION
When a user was being deleted from the application, the vero strategy wasn't unsubscribing the user from vero.
- [x] Hook a callback on strategy to unsubscribe the user before its removal.
